### PR TITLE
Corrected a Problem with the handleFocusIn function on the Select Form Component

### DIFF
--- a/src/components/Forms/Select/Select.tsx
+++ b/src/components/Forms/Select/Select.tsx
@@ -98,11 +98,15 @@ const BaseSelect = <T extends {}>(
 
 
   useEffect(() => {
+
     const handleFocusIn = (event: FocusEvent) => {
-      if (inputRef.current?.contains(event.target as Node)) {
-        setShowInput(true)
+      // Check if the focused element is either inside the inputRef or the containerRef
+      if (inputRef.current?.contains(event.target as Node)
+          || container.current?.contains(event.target as Node)) {
+        setShowInput(true);
       }
-    }
+    };
+    
 
     const handleFocusOut = () => {
       // this settimout is because the previously focused element is still focused when the focusout event fires


### PR DESCRIPTION
The handleFocusIn function was not working correctly.  If I already had an element selected, the control will not allow me to click on the field again and open the drop down list.  It was forcing me to clear the selection and then I could reopen the drop down.

This commit addresses this problem by checking to see if the focused element is either inside the inputRef or the containerRef.