### PR TITLE
make tab labels a react node for more flexibility

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -4,7 +4,7 @@ import { Conditional } from '../Conditional'
 
 type Tab = {
   id:React.Key
-  label:string
+  label:React.ReactNode
   content:() => React.ReactNode
 }
 


### PR DESCRIPTION
We have use cases where a tab's label needs to include more than just a string. This PR adjusts the type of the label prop on a tab to support a ReactNode. This is backwards compatible with strings so existing code using the current prop signature should not be affected, while we gain greater flexibility in what we can display in a tab's label.